### PR TITLE
"use base ..." => "use parent ..."

### DIFF
--- a/lib/Net/Disqus.pm
+++ b/lib/Net/Disqus.pm
@@ -5,7 +5,7 @@ use Try::Tiny;
 use Net::Disqus::UserAgent;
 use Net::Disqus::Interfaces;
 use Net::Disqus::Exception;
-use base 'Class::Accessor';
+use parent 'Class::Accessor';
 
 __PACKAGE__->mk_ro_accessors(qw(api_key api_secret api_url ua pass_api_errors));
 __PACKAGE__->mk_accessors(qw(interfaces rate_limit rate_limit_remaining rate_limit_reset fragment path));

--- a/lib/Net/Disqus/Exception.pm
+++ b/lib/Net/Disqus/Exception.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 package Net::Disqus::Exception;
-use base 'Class::Accessor';
+use parent 'Class::Accessor';
 use overload '""' => \&overload_text;
 __PACKAGE__->mk_accessors(qw(code text));
 


### PR DESCRIPTION
Because parent.pm is simpler and in core since 5.10.1.

From https://metacpan.org/pod/parent#HISTORY

> This module was forked from base to remove the cruft that had accumulated in it.
